### PR TITLE
Add Version Check to ignore setup:cron:run command if its Magento2.3.7 or later

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -28,7 +28,14 @@ fi
 
 ${PHP_BIN} "${INSTALLDIR}/bin/magento" cron:run | grep -v 'Ran jobs by schedule' >> "${INSTALLDIR}/var/log/magento.cron.log"
 ${PHP_BIN} "${INSTALLDIR}/update/cron.php" >> "${INSTALLDIR}/var/log/update.cron.log"
-${PHP_BIN} "${INSTALLDIR}/bin/magento" setup:cron:run >> "${INSTALLDIR}/var/log/setup.cron.log"
+
+MAGEVERSION=$( ${PHP_BIN} "${INSTALLDIR}/bin/magento" --version )
+MAGEVERSIONMINOR=$( echo ${MAGEVERSION} | awk -F'.' '{print $2}' )
+MAGEVERSIONPATCHLEVEL=$( echo ${MAGEVERSION} | awk -F'.' '{print $3}' )
+
+if [ ${MAGEVERSIONMINOR} -le 3 ] && [ ${MAGEVERSIONPATCHLEVEL} -le 6 ]; then
+        ${PHP_BIN} "${INSTALLDIR}/bin/magento" setup:cron:run >> "${INSTALLDIR}/var/log/setup.cron.log"
+fi
 
 wait
 


### PR DESCRIPTION
Successfully tested with the following versions:

- 2.4.2-p1 (latest)
- 2.3.7
- 2.3.6
- 2.3.2

**_Should_** also fix the problem stated in #1 