### PR TITLE
Fix Version Check for universal Magento2 cron.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Simply move to the root of your Magento2 installation and download cron.sh from 
 
     cd /path/to/magento2
     wget https://raw.githubusercontent.com/mittwald/magento2-cronjobs/master/cron.sh
+

--- a/cron.sh
+++ b/cron.sh
@@ -26,7 +26,7 @@ else
     exit 0
 fi
 
-${PHP_BIN} "${INSTALLDIR}/bin/magento" cron:run >> "${INSTALLDIR}/var/log/setup.cron.log" 
+${PHP_BIN} "${INSTALLDIR}/bin/magento" cron:run >> "${INSTALLDIR}/var/log/magento.cron.log" 
 ${PHP_BIN} "${INSTALLDIR}/update/cron.php" >> "${INSTALLDIR}/var/log/update.cron.log"
 
 MAGEVERSION=$( ${PHP_BIN} "${INSTALLDIR}/bin/magento" --version )

--- a/cron.sh
+++ b/cron.sh
@@ -31,7 +31,7 @@ ${PHP_BIN} "${INSTALLDIR}/update/cron.php" >> "${INSTALLDIR}/var/log/update.cron
 
 MAGEVERSION=$( ${PHP_BIN} "${INSTALLDIR}/bin/magento" --version )
 MAGEVERSIONMINOR=$( echo ${MAGEVERSION} | awk -F'.' '{print $2}' )
-MAGEVERSIONPATCHLEVEL=$( echo ${MAGEVERSION} | awk -F'.' '{print $3}' )
+MAGEVERSIONPATCHLEVEL=$( echo ${MAGEVERSION} | awk -F'.' '{print $3}' | awk -F'-' '{print $1}' )
 
 if [ ${MAGEVERSIONMINOR} -le 3 ] && [ ${MAGEVERSIONPATCHLEVEL} -le 6 ]; then
         ${PHP_BIN} "${INSTALLDIR}/bin/magento" setup:cron:run >> "${INSTALLDIR}/var/log/setup.cron.log"

--- a/cron.sh
+++ b/cron.sh
@@ -26,7 +26,7 @@ else
     exit 0
 fi
 
-${PHP_BIN} "${INSTALLDIR}/bin/magento" cron:run | grep -v 'Ran jobs by schedule' >> "${INSTALLDIR}/var/log/magento.cron.log"
+${PHP_BIN} "${INSTALLDIR}/bin/magento" cron:run >> "${INSTALLDIR}/var/log/setup.cron.log" 
 ${PHP_BIN} "${INSTALLDIR}/update/cron.php" >> "${INSTALLDIR}/var/log/update.cron.log"
 
 MAGEVERSION=$( ${PHP_BIN} "${INSTALLDIR}/bin/magento" --version )


### PR DESCRIPTION
Before, the Version check couldn't handle Release Candidates or Security Releases (-pX).
Successfully tested with the following Versions:

mage-2-3-3  
mage-2-3-4  
mage-2-3-5  
mage-2-3-6  
mage-2-3-7  
mage-2-3-7-p1  
mage-2-4-0  
mage-2-4-1
mage-2-4-2  
mage-2-4-2-p1  
mage-2-4-2-p2  
mage-2-4-3

Glad for every feedback.
